### PR TITLE
Stdweb spawn local future

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -32,7 +32,7 @@ history = []
 dsl = []
 effect = []
 fetch = ["serde", "serde_json", "neq", "future"]
-future = ["wasm-bindgen-futures", "wasm-bindgen", "futures", "web-sys"]
+future = ["wasm-bindgen-futures", "wasm-bindgen", "stdweb", "futures", "web-sys"]
 
 # Ptr features
 lrc = []
@@ -50,6 +50,7 @@ wasm-bindgen = {version = "0.2.51", features=["serde-serialize"], optional = tru
 futures = {version = "0.3.1", optional = true}
 serde = {version= "1.0.102", optional = true}
 serde_json = { version = "1.0.41", optional = true }
+stdweb = { version = "0.4.20", features = ["futures-support"], optional = true }
 
 [dependencies.web-sys]
 version = "0.3.31"

--- a/src/future.rs
+++ b/src/future.rs
@@ -26,7 +26,7 @@ impl <COMP: Component> ComponentLinkFuture for ComponentLink<COMP> {
         let mut link: ComponentLink<COMP>  = self.clone();
         let js_future = async move{
             let message: COMP::Message = future.await;
-            link.send_self(message);
+            link.send_message(message);
             Ok(JsValue::NULL)
         };
         future_to_promise(js_future);
@@ -37,7 +37,7 @@ impl <COMP: Component> ComponentLinkFuture for ComponentLink<COMP> {
         let mut link: ComponentLink<COMP> = self.clone();
         let js_future = async move {
             let messages: Vec<COMP::Message> = future.await;
-            link.send_self_batch(messages);
+            link.send_message_batch(messages);
             Ok(JsValue::NULL)
         };
         future_to_promise(js_future);

--- a/src/future.rs
+++ b/src/future.rs
@@ -3,8 +3,8 @@ use yew::{ComponentLink, Component, agent::{AgentLink, Agent}};
 use stdweb::spawn_local;
 
 
-/// Trait that allows you to use `ComponentLink`s to register futures.
-pub trait ComponentLinkFuture {
+/// Trait that allows you to use `ComponentLink` and `AgentLink` to register futures.
+pub trait LinkFuture {
     type Message;
     /// This method processes a Future that returns a message and sends it back to the component's
     /// loop.
@@ -19,7 +19,7 @@ pub trait ComponentLinkFuture {
     fn send_future_batch<F>(&self, future: F) where F: Future<Output=Vec<Self::Message>> + 'static;
 }
 
-impl <COMP: Component> ComponentLinkFuture for ComponentLink<COMP> {
+impl <COMP: Component> LinkFuture for ComponentLink<COMP> {
     type Message = COMP::Message;
 
     fn send_future<F>(&self, future: F) where F: Future<Output=Self::Message> + 'static {
@@ -42,18 +42,7 @@ impl <COMP: Component> ComponentLinkFuture for ComponentLink<COMP> {
     }
 }
 
-/// Trait that allows you to use `AgentLink`s to register futures.
-pub trait AgentLinkFuture {
-    type Message;
-    /// This method processes a Future that returns a message and sends it back to the component's
-    /// loop.
-    ///
-    /// # Panics
-    /// If the future panics, then the promise will not resolve, and will leak.
-    fn send_future<F>(&self, future: F) where F: Future<Output = Self::Message> + 'static;
-}
-
-impl <AGN: Agent> AgentLinkFuture for AgentLink<AGN> {
+impl <AGN: Agent> LinkFuture for AgentLink<AGN> {
     type Message = AGN::Message;
 
     fn send_future<F>(&self, future: F) where F: Future<Output=Self::Message> + 'static {
@@ -64,5 +53,9 @@ impl <AGN: Agent> AgentLinkFuture for AgentLink<AGN> {
             cb.emit(message);
         };
         spawn_local(js_future);
+    }
+
+    fn send_future_batch<F>(&self, _future: F) where F: Future<Output=Vec<Self::Message>> + 'static {
+        unimplemented!("Agents don't support batching their messages.")
     }
 }

--- a/src/future.rs
+++ b/src/future.rs
@@ -1,7 +1,7 @@
 use std::future::Future;
-use yew::{ComponentLink, Component};
-use wasm_bindgen::JsValue;
-use wasm_bindgen_futures::future_to_promise;
+use yew::{ComponentLink, Component, agent::{AgentLink, Agent}};
+use stdweb::spawn_local;
+
 
 /// Trait that allows you to use `ComponentLink`s to register futures.
 pub trait ComponentLinkFuture {
@@ -27,9 +27,8 @@ impl <COMP: Component> ComponentLinkFuture for ComponentLink<COMP> {
         let js_future = async move{
             let message: COMP::Message = future.await;
             link.send_message(message);
-            Ok(JsValue::NULL)
         };
-        future_to_promise(js_future);
+        spawn_local(js_future);
 
     }
 
@@ -38,8 +37,7 @@ impl <COMP: Component> ComponentLinkFuture for ComponentLink<COMP> {
         let js_future = async move {
             let messages: Vec<COMP::Message> = future.await;
             link.send_message_batch(messages);
-            Ok(JsValue::NULL)
         };
-        future_to_promise(js_future);
+        spawn_local(js_future);
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -54,5 +54,5 @@ mod effect;
 #[cfg(feature = "effect")]
 pub use effect::{Effect, effect};
 
-#[cfg(all(target_arch = "wasm32", not(target_os="wasi"), not(cargo_web), feature = "future"))]
+#[cfg(feature = "future")]
 pub mod future;

--- a/src/not_equal_assign.rs
+++ b/src/not_equal_assign.rs
@@ -39,7 +39,7 @@ pub trait NeqAssign<NEW> {
     ///         self.props.neq_assign(props)
     ///     }
     ///#
-    ///#     fn view(&self) -> VNode<Self> {
+    ///#     fn view(&self) -> VNode {
     ///#         unimplemented!()
     ///#     }
     ///  }


### PR DESCRIPTION
- Fix not equal assign example
- Rename `send_self` `send_self_batch` to `send_message` `send_message_batch`
- Use stdweb::spawn_local to execute futures sent to send_future
- Add AgentLinkFuture trait and implementation

Futures successfully executed and sent back message to the Component/Agent using `cargo web` and asmjs target.
Also tested with wasm32-unknown-unknown target and it work great 

Issue: https://github.com/yewstack/yew/issues/776

It depends on https://github.com/yewstack/yew/pull/802 for `AgentLinkFuture` to work