### PR TITLE
Function Components

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -77,5 +77,6 @@ members = [
     "examples/mrc_irc",
     "examples/effect",
     "examples/fetch",
-    "examples/futures"
+    "examples/futures",
+    "examples/function_component"
 ]

--- a/crates/yewtil-macro/Cargo.toml
+++ b/crates/yewtil-macro/Cargo.toml
@@ -10,6 +10,6 @@ description = "Macros to be re-exported from the yewtil crate"
 proc-macro = true
 
 [dependencies]
-syn = "1.0.8"
+syn = "1.0.11"
 quote = "1.0.2"
 proc-macro2 = "1.0.6"

--- a/crates/yewtil-macro/src/function_component.rs
+++ b/crates/yewtil-macro/src/function_component.rs
@@ -1,0 +1,147 @@
+use proc_macro2::{TokenStream, Ident, Span};
+use proc_macro::TokenStream as TokenStream1;
+use syn::{Visibility, Error, Field, Stmt, Block, VisPublic};
+use syn::Token;
+use syn::token;
+use syn::punctuated::Punctuated;
+use syn::parse::{Parse, ParseBuffer};
+use syn::{parenthesized, braced};
+use syn::parse_macro_input;
+use syn::export::ToTokens;
+use quote::quote;
+
+pub fn function_component_handler(attr: TokenStream, item: TokenStream1) -> TokenStream1 {
+    let component_name = attr.to_string();
+    assert!(!component_name.is_empty(), "you must provide a component name. eg: function_component(MyComponent)");
+    let component_name = Ident::new(&component_name, Span::call_site());
+
+    let item_copy = item.clone();
+
+    let function = parse_macro_input!(item_copy as Function);
+
+    TokenStream1::from(FunctionComponentInfo {
+        component_name,
+        function
+    }.to_token_stream())
+}
+
+pub struct FunctionComponentInfo {
+    component_name: Ident,
+    function: Function
+}
+
+
+// TODO, support type parameters
+
+pub struct Function {
+    pub vis: Visibility,
+    pub fn_token: Token![fn],
+    pub name: Ident,
+    pub paren_token: token::Paren,
+    pub fields: Punctuated<Field, Token![,]>,
+    pub returns_token: Token![->],
+    pub return_ty: Ident,
+    pub brace_token: token::Brace,
+    pub body: Vec<Stmt>
+}
+
+impl Parse for Function {
+    fn parse(input: &ParseBuffer) -> Result<Self, Error> {
+        let content;
+        let content2;
+        Ok(Function {
+            vis: input.parse()?,
+            fn_token: input.parse()?,
+            name: input.parse()?,
+            paren_token: parenthesized!(content in input),
+            fields: content.parse_terminated(Field::parse_named)?,
+            returns_token: input.parse()?,
+            return_ty: input.parse()?,
+            brace_token: braced!(content2 in input),
+            body: content2.call(Block::parse_within)?
+        })
+    }
+}
+
+impl ToTokens for Function {
+    fn to_tokens(&self, tokens: &mut TokenStream) {
+        let Function {
+            vis, fn_token, name, fields, returns_token, return_ty,  body, ..
+        } = self;
+        let fields = fields.iter()
+            .map(|field: &Field| {
+                let mut new_field: Field = field.clone();
+                new_field.attrs = vec![];
+                new_field
+            })
+            .collect::<Punctuated<_, Token![,]>>();
+
+        tokens.extend(quote! {
+            #vis #fn_token #name(#fields) #returns_token #return_ty {
+                #(#body)*
+            }
+        })
+    }
+}
+
+impl ToTokens for FunctionComponentInfo {
+    fn to_tokens(&self, tokens: &mut TokenStream) {
+        let FunctionComponentInfo {
+            component_name, function
+        } = self;
+        let function_impl = quote!{#function};
+        let Function {
+            name, fields, ..
+        } = function;
+
+        let impl_name = format!("Pure{}", component_name.to_string());
+        let impl_name = Ident::new(&impl_name, Span::call_site());
+
+        let alias = quote! {
+            pub type #component_name = Pure<#impl_name>;
+        };
+
+        // Set the fields to be public
+        let public_fields = fields.iter()
+            .map(|field: &Field| {
+                let mut new_field: Field = field.clone();
+                let visibility = Visibility::Public(VisPublic{ pub_token: syn::token::Pub {span: Span::call_site()} });
+                new_field.vis = visibility;
+                new_field
+            })
+            .collect::<Punctuated<_, Token![,]>>();
+
+
+        let component_struct = quote!{
+            #[derive(Clone, PartialEq, Properties)]
+            pub struct #impl_name {
+                #public_fields
+            }
+        };
+
+        let arguments = fields.iter()
+            .map(|field| {
+                let field = field.ident.as_ref().expect("Field must have name");
+                quote! {
+                    self.#field.clone() // TODO this clone here is expensive, instead have the function take &refs and strip them when making the component struct impl.
+                }
+            })
+            .collect::<Punctuated<_, Token![,]>>();
+
+        let pure_component_impl = quote! {
+            impl PureComponent for #impl_name {
+                fn render(&self) -> VNode {
+                     #name(#arguments)
+                }
+            }
+        };
+
+
+        tokens.extend(quote!{
+            #function_impl
+            #alias
+            #component_struct
+            #pure_component_impl
+        })
+    }
+}

--- a/crates/yewtil-macro/src/function_component.rs
+++ b/crates/yewtil-macro/src/function_component.rs
@@ -92,14 +92,14 @@ impl ToTokens for FunctionComponentInfo {
         // The function tokens must be re-generated in order to strip the attributes that are not allowed.
         let function_token_stream = function.to_token_stream();
         let Function {
-            name, fields, ..
+            vis, name, fields, ..
         } = function;
 
         let impl_name = format!("FuncComp{}", component_name.to_string());
         let impl_name = Ident::new(&impl_name, Span::call_site());
 
         let alias = quote! {
-            pub type #component_name = ::yewtil::Pure<#impl_name>;
+            #vis type #component_name = ::yewtil::Pure<#impl_name>;
         };
 
         // Set the fields to be public and strips references as necessary.
@@ -128,7 +128,7 @@ impl ToTokens for FunctionComponentInfo {
 
         let component_struct = quote!{
             #[derive(::std::clone::Clone, ::std::cmp::PartialEq, ::yew::Properties)]
-            pub struct #impl_name {
+            #vis struct #impl_name {
                 #new_fields
             }
         };

--- a/crates/yewtil-macro/src/lib.rs
+++ b/crates/yewtil-macro/src/lib.rs
@@ -11,6 +11,13 @@ use syn::{parse_macro_input, DeriveInput, Error, Field, Type};
 mod util;
 use util::extract_type_from_callback;
 use std::fmt;
+use crate::function_component::function_component_handler;
+
+mod function_component;
+#[proc_macro_attribute]
+pub fn function_component(attr: TokenStream, item: TokenStream) -> TokenStream {
+    function_component_handler(attr.into(), item.into()).into()
+}
 
 #[proc_macro_derive(Emissive, attributes(props))]
 pub fn emissive(tokens: TokenStream) -> TokenStream {

--- a/examples/function_component/Cargo.toml
+++ b/examples/function_component/Cargo.toml
@@ -1,0 +1,13 @@
+[package]
+name = "function_component"
+version = "0.1.0"
+authors = ["Henry Zimmerman <zimhen7@gmail.com>"]
+edition = "2018"
+
+# See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
+
+[dependencies]
+yew = { git = "https://github.com/yewstack/yew", branch="master" }
+yewtil = {path="../.."}
+web_logger = "0.2.0"
+log = "0.4.8"

--- a/examples/function_component/src/button.rs
+++ b/examples/function_component/src/button.rs
@@ -1,13 +1,13 @@
-use yew::virtual_dom::VNode;
-use yew::{html, Callback, Properties, ClickEvent, Html};
-use yewtil::{Pure, PureComponent, function_component};
+use yew::{html, Callback, ClickEvent, Html};
+use yewtil::{function_component};
 
 #[function_component(Button)]
 pub fn button(
     #[props(required)]
-    callback: Callback<ClickEvent>,
-    text: String)
-    -> Html {
+    callback: &Callback<ClickEvent>,
+    text: &String,
+    _num: usize
+) -> Html {
     html! {
         <button onclick=callback>{ text }</button>
     }

--- a/examples/function_component/src/button.rs
+++ b/examples/function_component/src/button.rs
@@ -1,0 +1,16 @@
+use yew::virtual_dom::VNode;
+use yew::{html, Callback, Properties, ClickEvent, Html};
+use yewtil::{Pure, PureComponent, function_component};
+
+#[function_component(Button)]
+pub fn button(
+    #[props(required)]
+    callback: Callback<ClickEvent>,
+    text: String)
+    -> Html {
+    html! {
+        <button onclick=callback>{ text }</button>
+    }
+}
+
+

--- a/examples/function_component/src/main.rs
+++ b/examples/function_component/src/main.rs
@@ -1,0 +1,40 @@
+
+use yew::{html, Component, ComponentLink, Html, ShouldRender};
+
+mod button;
+use crate::button::Button;
+
+pub struct Model {link: ComponentLink<Self>}
+
+pub enum Msg {
+    DoIt,
+}
+
+impl Component for Model {
+    type Message = Msg;
+    type Properties = ();
+
+    fn create(_: Self::Properties, link: ComponentLink<Self>) -> Self {
+        Model {link}
+    }
+
+    fn update(&mut self, msg: Self::Message) -> ShouldRender {
+        match msg {
+            Msg::DoIt => {
+                log::info!("got message");
+                true
+            }
+        }
+    }
+
+    fn view(&self) -> Html {
+        html! {
+            <Button callback=self.link.callback(|_| Msg::DoIt) text = "Click me!" />
+        }
+    }
+}
+
+fn main() {
+    web_logger::init();
+    yew::start_app::<Model>();
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -42,6 +42,9 @@ pub use pure::{Pure, PureComponent};
 #[cfg(feature = "pure")]
 pub use yewtil_macro::Emissive;
 
+#[cfg(feature = "pure")]
+pub use yewtil_macro::function_component;
+
 
 //#[cfg(feature = "with_callback")]
 //pub use with_callback::WithCallback;
@@ -56,3 +59,4 @@ pub use effect::{Effect, effect};
 
 #[cfg(feature = "future")]
 pub mod future;
+


### PR DESCRIPTION
Enable defining pure components by just using a function.

It currently is not hygienic - requiring that all relevant imports happen outside the macro, and currently adds another unneeded `clone` call.
Future commits will resolve these issues.

Closes https://github.com/yewstack/yewtil/issues/8