### PR TITLE
Updated Yew version to 14

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -39,8 +39,7 @@ lrc = []
 mrc_irc = []
 
 [dependencies]
-yew = { git = "https://github.com/yewstack/yew", branch="master" }
-#yew = "0.10.0"
+yew = "0.14"
 yewtil-macro = {path = "crates/yewtil-macro", version="0.1.0", optional=true}
 log = "0.4.8"
 


### PR DESCRIPTION
Simple update in Cargo.toml from Yew version 0.10 to version 0.14. No compatibility test has been done yet. So far Pure components work. Should solve also #43, but as no CI is set yet ( #16) no test can be done.